### PR TITLE
Add option to run ASPECT in parallel

### DIFF
--- a/aspect-docker
+++ b/aspect-docker
@@ -7,25 +7,23 @@
 #   ./aspect-docker my-model.prm
 
 
-# Docker image and tag
-IMAGE=gassmoeller/aspect
-TAG=latest
+# Define function to print usage help
+function usage() {
+	echo "Usage: $0 [-p PROCESSORS] <model-file>"
+}
 
-# Define HOME directory inside the container
-GUEST_HOME=/home/dealii
 
-# Path to aspect binary inside the container
-ASPECT=$GUEST_HOME/aspect/aspect
-
-# Target where the host directory will be mounted
-MOUNT_DIR=$GUEST_HOME/model
-
-# Get the model filename and the number of processors from the argument
+# --------------
+# Read arguments
+# --------------
 MODEL_PATH=""
 PROCESSORS=1
+
 while [[ $# -gt 0 ]]; do
     argument=$1
     case $argument in
+		-h|--help)
+			usage && exit 0;;
         -p|--processors)
             PROCESSORS=$2
             shift  # past argument
@@ -40,8 +38,7 @@ done
 
 # Check if model filename has been passed as argument
 if [ -z "$MODEL_PATH" ]; then
-    echo ERROR: You must define a model file in order to run ASPECT
-    exit
+    usage && exit 0
 fi
 
 # Check if model filename exists
@@ -56,11 +53,32 @@ if [ $PROCESSORS -gt 1 ]; then
     PARALLEL_PREFIX="mpirun -np $PROCESSORS"
 fi
 
+
+# ----------------------------------------
+# Define variables related to Docker image
+# ----------------------------------------
+
+# Docker image and tag
+IMAGE=gassmoeller/aspect
+TAG=latest
+
+# Define HOME directory inside the container
+GUEST_HOME=/home/dealii
+
+# Path to aspect binary inside the container
+ASPECT=$GUEST_HOME/aspect/aspect
+
+# Target where the host directory will be mounted
+MOUNT_DIR=$GUEST_HOME/model
+
 # Get output directory from the .prm file
 OUTPUT_DIR_NAME=$(grep -i "set Output directory" $MODEL_PATH | awk '{printf $NF}')
 
 # Set the path where the output will be copied
 OUTPUT_DIR=$(dirname $MODEL_PATH)/$OUTPUT_DIR
 
+
+# ----------
 # Run ASPECT
+# ----------
 docker run --rm -it -v "$(pwd):$MOUNT_DIR" $IMAGE:$TAG /bin/bash -c "$PARALLEL_PREFIX $ASPECT $MOUNT_DIR/$MODEL_PATH; cp -r $OUTPUT_DIR_NAME $MOUNT_DIR/$OUTPUT_DIR"

--- a/aspect-docker
+++ b/aspect-docker
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Written by Santiago Soler <santiago.r.soler@gmail.com> and 
+# Written by Santiago Soler <santiago.r.soler@gmail.com> and
 # Agustina Pesce <pesce.agustina@gmail.com>
 # See https://www.github.com/aguspesce/aspect-docker for more information.
 #
@@ -20,8 +20,41 @@ ASPECT=$GUEST_HOME/aspect/aspect
 # Target where the host directory will be mounted
 MOUNT_DIR=$GUEST_HOME/model
 
-# Get the model filename from the first argument
-MODEL_PATH=$1
+# Get the model filename and the number of processors from the argument
+MODEL_PATH=""
+PROCESSORS=1
+while [[ $# -gt 0 ]]; do
+    argument=$1
+    case $argument in
+        -p|--processors)
+            PROCESSORS=$2
+            shift  # past argument
+            shift  # past value
+            ;;
+        *)  # ASPECT script filename
+            MODEL_PATH=$1
+            shift  # past script filename
+            ;;
+    esac
+done
+
+# Check if model filename has been passed as argument
+if [ -z "$MODEL_PATH" ]; then
+    echo ERROR: You must define a model file in order to run ASPECT
+    exit
+fi
+
+# Check if model filename exists
+if [ ! -f "$MODEL_PATH" ]; then
+    echo ERROR: Model file $MODEL_PATH not found
+    exit
+fi
+
+# Define prefix for using mpirun in case the user wants to parallelize the run
+PARALLEL_PREFIX=""
+if [ $PROCESSORS -gt 1 ]; then
+    PARALLEL_PREFIX="mpirun -np $PROCESSORS"
+fi
 
 # Get output directory from the .prm file
 OUTPUT_DIR_NAME=$(grep -i "set Output directory" $MODEL_PATH | awk '{printf $NF}')
@@ -30,4 +63,4 @@ OUTPUT_DIR_NAME=$(grep -i "set Output directory" $MODEL_PATH | awk '{printf $NF}
 OUTPUT_DIR=$(dirname $MODEL_PATH)/$OUTPUT_DIR
 
 # Run ASPECT
-docker run --rm -it -v "$(pwd):$MOUNT_DIR" $IMAGE:$TAG /bin/bash -c "$ASPECT $MOUNT_DIR/$MODEL_PATH; cp -r $OUTPUT_DIR_NAME $MOUNT_DIR/$OUTPUT_DIR"
+docker run --rm -it -v "$(pwd):$MOUNT_DIR" $IMAGE:$TAG /bin/bash -c "$PARALLEL_PREFIX $ASPECT $MOUNT_DIR/$MODEL_PATH; cp -r $OUTPUT_DIR_NAME $MOUNT_DIR/$OUTPUT_DIR"


### PR DESCRIPTION
Add option `-p` or `--processors` for specifying how many processors wants to be used on the ASPECT run.
Add also a `-h` or `--help` option showing how to use the script.
The option handling was implemented through `case` statements

Fix #2 